### PR TITLE
feat: add Redis Insight

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,7 @@
 <!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ```bash
+ddev add-on get ddev/ddev-redis
 ddev add-on get https://github.com/stasadev/ddev-redis-insight/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@
 
 ## Overview
 
+[Redis Insight](https://redis.io/insight/) is a visual tool that provides capabilities to design, develop, and optimize your Redis application. Query, analyse and interact with your Redis data.
+
 This add-on integrates Redis Insight into your [DDEV](https://ddev.com/) project.
+
+## Requirements
+
+Before installing this add-on, the [Redis service](https://github.com/ddev/ddev-redis) must be available:
+
+```bash
+ddev add-on get ddev/ddev-redis
+```
 
 ## Installation
 
@@ -22,15 +32,21 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 | Command | Description |
 | ------- | ----------- |
+| `ddev redis-insight` | Open Redis Insight in your browser (`https://<project>.ddev.site:5540`) |
 | `ddev describe` | View service status and used ports for Redis Insight |
 | `ddev logs -s redis-insight` | Check Redis Insight logs |
 
 ## Advanced Customization
 
+You may need to adjust the password depending on your Redis configuration:
+
+* A `docker-compose.redis-insight_password.yaml` file is automatically created on install, if we detect that Redis needs one.
+* By default, the password is set via `REDIS_PASSWORD=redis` in that file. If you modify it, be sure to remove the `#ddev-generated` comment to prevent your changes from being overwritten.
+
 To change the Docker image:
 
 ```bash
-ddev dotenv set .ddev/.env.redis-insight --redis-insight-docker-image="busybox:stable"
+ddev dotenv set .ddev/.env.redis-insight --redis-insight-docker-image="redis/redisinsight:latest"
 ddev add-on get stasadev/ddev-redis-insight
 ddev restart
 ```
@@ -41,7 +57,7 @@ All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
-| `REDIS_INSIGHT_DOCKER_IMAGE` | `--redis-insight-docker-image` | `busybox:stable` |
+| `REDIS_INSIGHT_DOCKER_IMAGE` | `--redis-insight-docker-image` | `redis/redisinsight:latest` |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After installation, make sure to commit the `.ddev` directory to version control
 You may need to adjust the password depending on your Redis configuration:
 
 * A `docker-compose.redis-insight_password.yaml` file is automatically created on install, if we detect that Redis needs one.
-* By default, the password is set via `REDIS_PASSWORD=redis` in that file. If you modify it, be sure to remove the `#ddev-generated` comment to prevent your changes from being overwritten.
+* By default, the password is set via `RI_REDIS_PASSWORD=redis` in that file. If you modify it, be sure to remove the `#ddev-generated` comment to prevent your changes from being overwritten.
 
 To change the Docker image:
 

--- a/commands/host/redis-insight
+++ b/commands/host/redis-insight
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Launch a browser with Redis Insight
+## Usage: redis-insight
+## Example: "ddev redis-insight"
+
+# Determine whether to use HTTP or HTTPS based on environment
+PROTOCOL="HTTP"
+if [ "${DDEV_PRIMARY_URL%://*}" != "http" ] && [ -z "${GITPOD_WORKSPACE_ID:-}" ] && [ "${CODESPACES:-}" != "true" ]; then
+    PROTOCOL="HTTPS"
+fi
+
+# Fetch the appropriate port within the redis-insight container
+DDEV_REDIS_INSIGHT_PORT=$(ddev exec -s redis-insight sh -c "printenv | grep -w ${PROTOCOL}_EXPOSE | cut -d '=' -f 2 | cut -d ':' -f 1")
+
+if [ -z "$DDEV_REDIS_INSIGHT_PORT" ]; then
+    echo "Error: Could not retrieve Redis Insight port."
+    exit 1
+fi
+
+ddev launch :"$DDEV_REDIS_INSIGHT_PORT"

--- a/docker-compose.redis-insight.yaml
+++ b/docker-compose.redis-insight.yaml
@@ -1,16 +1,24 @@
 #ddev-generated
-# Simple template to demonstrate redis-insight
 services:
   redis-insight:
     container_name: ddev-${DDEV_SITENAME}-redis-insight
-    image: ${REDIS_INSIGHT_DOCKER_IMAGE:-busybox:stable}
-    command: tail -f /dev/null
+    image: ${REDIS_INSIGHT_DOCKER_IMAGE:-redis/redisinsight:latest}
     restart: "no"
     # These labels ensure this service is discoverable by DDEV.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-
+    environment:
+      - RI_REDIS_HOST=redis
+      - RI_REDIS_PORT=6379
+      - RI_APP_PORT=5540
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=5539:5540
+      - HTTPS_EXPOSE=5540:5540
     volumes:
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
+      - redis-insight:/data
+
+volumes:
+  redis-insight:

--- a/docker-compose.redis-insight_norouter.yaml
+++ b/docker-compose.redis-insight_norouter.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+# If omit_containers[ddev-router] then this file will be replaced
+# with another with a `ports` statement to directly expose port 5540 to 5540
+services: {}

--- a/install.yaml
+++ b/install.yaml
@@ -18,7 +18,7 @@ post_install_actions:
     fi
   - |
     #ddev-description:If Redis is optimized, set a password
-    if [ $(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null) = "true" ]; then
+    if [ "$(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null)" = "true" ]; then
       printf "#ddev-generated\nservices:\n  redis-insight:\n    environment:\n      - RI_REDIS_PASSWORD=redis\n" > docker-compose.redis-insight_password.yaml
     fi
   - |

--- a/install.yaml
+++ b/install.yaml
@@ -19,7 +19,7 @@ post_install_actions:
   - |
     #ddev-description:If Redis is optimized, set a password
     if [ $(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null) = "true" ]; then
-      printf "#ddev-generated\nservices:\n  redis-insight:\n    environment:\n      - REDIS_PASSWORD=redis\n" > docker-compose.redis-insight_password.yaml
+      printf "#ddev-generated\nservices:\n  redis-insight:\n    environment:\n      - RI_REDIS_PASSWORD=redis\n" > docker-compose.redis-insight_password.yaml
     fi
   - |
     echo "You can now use 'ddev redis-insight' to launch Redis Insight UI"

--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,37 @@
 name: redis-insight
 
+dependencies:
+  - redis
+
 project_files:
   - docker-compose.redis-insight.yaml
+  - docker-compose.redis-insight_norouter.yaml
+  - commands/host/redis-insight
 
 ddev_version_constraint: '>= v1.24.3'
+
+post_install_actions:
+  - |
+    #ddev-description:If router disabled, directly expose port
+    if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
+      printf "#ddev-generated\nservices:\n  redis-insight:\n    ports:\n      - 5540:5540\n" > docker-compose.redis-insight_norouter.yaml
+    fi
+  - |
+    #ddev-description:If Redis is optimized, set a password
+    if [ $(ddev dotenv get .ddev/.env.redis --redis-optimized 2>/dev/null) = "true" ]; then
+      printf "#ddev-generated\nservices:\n  redis-insight:\n    environment:\n      - REDIS_PASSWORD=redis\n" > docker-compose.redis-insight_password.yaml
+    fi
+  - |
+    echo "You can now use 'ddev redis-insight' to launch Redis Insight UI"
+
+removal_actions:
+  - |
+    #ddev-description:Remove docker-compose.redis-insight_password.yaml file
+    file=docker-compose.redis-insight_password.yaml
+    if [ -f "${file}" ]; then
+      if grep -q '#ddev-generated' "${file}"; then
+        rm -f "${file}"
+      else
+        echo "Unwilling to remove '$DDEV_APPROOT/.ddev/${file}' because it does not have #ddev-generated in it; you can manually delete it if it is safe to delete."
+      fi
+    fi


### PR DESCRIPTION
## The Issue

Implement Redis Insight based on https://github.com/ddev/ddev-redis-commander

## How This PR Solves The Issue

Adds it.

## Manual Testing Instructions

```bash
ddev add-on get ddev/ddev-redis
ddev add-on get https://github.com/stasadev/ddev-redis-insight/tarball/refs/pull/1/head
ddev restart
ddev redis-insight
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
