### PR TITLE
fix: use full path for redis dependency

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,7 @@
 name: redis-insight
 
 dependencies:
-  - redis
+  - ddev/ddev-redis
 
 project_files:
   - docker-compose.redis-insight.yaml


### PR DESCRIPTION
## The Issue

Similar to:

- https://github.com/ddev/ddev-redis-commander/pull/28

```
$ ddev add-on get stasadev/ddev-redis-insight
Installing stasadev/ddev-redis-insight:v1.0.0 
v1.0.0_216974839.tar.gz 9.18 KiB / ? [-----------------------------------------------=--------------------------]  94.02% 0s 
The add-on 'redis-insight' declares a dependency on 'redis'; Please ddev add-on get redis first.
```

## How This PR Solves The Issue

Uses full dependency name.

## Manual Testing Instructions

```bash
$ ddev add-on get https://github.com/stasadev/ddev-redis-insight/tarball/refs/pull/3/head
head_1976358685.tar.gz 9.18 KiB / ? [-----------------------=---------------------------------------------------]  94.00% 0s 
The add-on 'redis-insight' declares a dependency on 'ddev/ddev-redis'; Please ddev add-on get ddev/ddev-redis first.
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
